### PR TITLE
RouteHeader should not be removed which is added in SipCommandSampler UI if OutBound Proxy Enabled case

### DIFF
--- a/src/main/java/com/hpe/simulap/protocol/sip/sampler/SipSampler.java
+++ b/src/main/java/com/hpe/simulap/protocol/sip/sampler/SipSampler.java
@@ -851,6 +851,8 @@ public class SipSampler extends AbstractSampler implements TestStateListener, Te
                         requestURI = addressFactory.createSipURI(req[0], req[1] );
                         ackRequest.setRequestURI(requestURI);
                     }
+				 // add other headers
+                    addHeaders(ackRequest);
                     
                     // Route header
                     ArrayList<RouteHeader> routeHeaders = createRouteHeader();
@@ -860,10 +862,6 @@ public class SipSampler extends AbstractSampler implements TestStateListener, Te
                         	ackRequest.addHeader(routeHeader);
                         }
                     }
-
-
-                    // add other headers
-                    addHeaders(ackRequest);
 
                     // Body part
                     String body = getPropertyAsString("sip.body.text");
@@ -1136,6 +1134,8 @@ public class SipSampler extends AbstractSampler implements TestStateListener, Te
             	if (_logger.isDebugEnabled()) _logger.debug("contact header automatically set.");
             }            
 
+            // add other headers
+            addHeaders(request);
             // Route header
             ArrayList<RouteHeader> routeHeaders = createRouteHeader();
             if (routeHeaders != null) {
@@ -1144,10 +1144,6 @@ public class SipSampler extends AbstractSampler implements TestStateListener, Te
                 	request.addHeader(routeHeader);
                 }
             }
-            
-            // add other headers
-            addHeaders(request);
-            
             ClientTransaction ct = null;
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your PR in the Title above -->
## Description
For SIP calls, the plugin is not adding routes extracted from invite-200 OK in SIP ACK message, because of this the SIP calls are failing
Fixes #24.

<!--- Describe your PR in detail here -->
in case of outbound proxy enabled case , Route header should be deleted from sip stack.
but Route header should be added which in SipCommandSampler UI.

Changes proposed in this pull request:
- First remove the Route header from ACK request or In Dialog request if outbound Proxy enabled case
- Add Route Header if added in the SipCommandSampler

<!--- Do not assign the PR to someone -->
<!--- Do not give the issue a milestone -->
<!--- Give the PR a label as following:
- a `bug` you experienced by testing with the plugin,
- an `enhancements` you required to lead your tests with the plugin. -->

## Resources
<!--- (if appropriate):
- possible screenshots,
- small test scenario (`.jmx` file) to highlight the changes.
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [X] I give my PR a label.
- [X] I provide the required resources.
